### PR TITLE
Feat/#16 postgre sql 모델 및 alembic 초기 세팅

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,149 @@
+# A generic, single database configuration.
+
+[alembic]
+# path to migration scripts.
+# this is typically a path given in POSIX (e.g. forward slashes)
+# format, relative to the token %(here)s which refers to the location of this
+# ini file
+script_location = %(here)s/alembic
+
+# template used to generate migration file names; The default value is %%(rev)s_%%(slug)s
+# Uncomment the line below if you want the files to be prepended with date and time
+# see https://alembic.sqlalchemy.org/en/latest/tutorial.html#editing-the-ini-file
+# for all available tokens
+# file_template = %%(year)d_%%(month).2d_%%(day).2d_%%(hour).2d%%(minute).2d-%%(rev)s_%%(slug)s
+# Or organize into date-based subdirectories (requires recursive_version_locations = true)
+# file_template = %%(year)d/%%(month).2d/%%(day).2d_%%(hour).2d%%(minute).2d_%%(second).2d_%%(rev)s_%%(slug)s
+
+# sys.path path, will be prepended to sys.path if present.
+# defaults to the current working directory.  for multiple paths, the path separator
+# is defined by "path_separator" below.
+prepend_sys_path = .
+
+
+# timezone to use when rendering the date within the migration file
+# as well as the filename.
+# If specified, requires the tzdata library which can be installed by adding
+# `alembic[tz]` to the pip requirements.
+# string value is passed to ZoneInfo()
+# leave blank for localtime
+# timezone =
+
+# max length of characters to apply to the "slug" field
+# truncate_slug_length = 40
+
+# set to 'true' to run the environment during
+# the 'revision' command, regardless of autogenerate
+# revision_environment = false
+
+# set to 'true' to allow .pyc and .pyo files without
+# a source .py file to be detected as revisions in the
+# versions/ directory
+# sourceless = false
+
+# version location specification; This defaults
+# to <script_location>/versions.  When using multiple version
+# directories, initial revisions must be specified with --version-path.
+# The path separator used here should be the separator specified by "path_separator"
+# below.
+# version_locations = %(here)s/bar:%(here)s/bat:%(here)s/alembic/versions
+
+# path_separator; This indicates what character is used to split lists of file
+# paths, including version_locations and prepend_sys_path within configparser
+# files such as alembic.ini.
+# The default rendered in new alembic.ini files is "os", which uses os.pathsep
+# to provide os-dependent path splitting.
+#
+# Note that in order to support legacy alembic.ini files, this default does NOT
+# take place if path_separator is not present in alembic.ini.  If this
+# option is omitted entirely, fallback logic is as follows:
+#
+# 1. Parsing of the version_locations option falls back to using the legacy
+#    "version_path_separator" key, which if absent then falls back to the legacy
+#    behavior of splitting on spaces and/or commas.
+# 2. Parsing of the prepend_sys_path option falls back to the legacy
+#    behavior of splitting on spaces, commas, or colons.
+#
+# Valid values for path_separator are:
+#
+# path_separator = :
+# path_separator = ;
+# path_separator = space
+# path_separator = newline
+#
+# Use os.pathsep. Default configuration used for new projects.
+path_separator = os
+
+# set to 'true' to search source files recursively
+# in each "version_locations" directory
+# new in Alembic version 1.10
+# recursive_version_locations = false
+
+# the output encoding used when revision files
+# are written from script.py.mako
+# output_encoding = utf-8
+
+# database URL.  This is consumed by the user-maintained env.py script only.
+# other means of configuring database URLs may be customized within the env.py
+# file.
+sqlalchemy.url = driver://user:pass@localhost/dbname
+
+
+[post_write_hooks]
+# post_write_hooks defines scripts or Python functions that are run
+# on newly generated revision scripts.  See the documentation for further
+# detail and examples
+
+# format using "black" - use the console_scripts runner, against the "black" entrypoint
+# hooks = black
+# black.type = console_scripts
+# black.entrypoint = black
+# black.options = -l 79 REVISION_SCRIPT_FILENAME
+
+# lint with attempts to fix using "ruff" - use the module runner, against the "ruff" module
+# hooks = ruff
+# ruff.type = module
+# ruff.module = ruff
+# ruff.options = check --fix REVISION_SCRIPT_FILENAME
+
+# Alternatively, use the exec runner to execute a binary found on your PATH
+# hooks = ruff
+# ruff.type = exec
+# ruff.executable = ruff
+# ruff.options = check --fix REVISION_SCRIPT_FILENAME
+
+# Logging configuration.  This is also consumed by the user-maintained
+# env.py script only.
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARNING
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARNING
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/alembic/README
+++ b/alembic/README
@@ -1,0 +1,1 @@
+Generic single-database configuration.

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,0 +1,52 @@
+import asyncio
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy.ext.asyncio import async_engine_from_config
+
+from app.core.config import get_settings
+from app.models.base import Base
+from app.models.portfolio_chunk import PortfolioChunk  # noqa: F401 — ensures model is registered
+
+config = context.config
+config.set_main_option("sqlalchemy.url", get_settings().database_url)
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+target_metadata = Base.metadata
+
+
+def run_migrations_offline() -> None:
+    url = get_settings().database_url.replace("+asyncpg", "")
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def do_run_migrations(connection) -> None:
+    context.configure(connection=connection, target_metadata=target_metadata)
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+async def run_migrations_online() -> None:
+    connectable = async_engine_from_config(
+        config.get_section(config.config_ini_section, {}),
+        prefix="sqlalchemy.",
+        connect_args={"ssl": False},
+    )
+    async with connectable.connect() as connection:
+        await connection.run_sync(do_run_migrations)
+    await connectable.dispose()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    asyncio.run(run_migrations_online())

--- a/alembic/script.py.mako
+++ b/alembic/script.py.mako
@@ -1,0 +1,28 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision: str = ${repr(up_revision)}
+down_revision: Union[str, Sequence[str], None] = ${repr(down_revision)}
+branch_labels: Union[str, Sequence[str], None] = ${repr(branch_labels)}
+depends_on: Union[str, Sequence[str], None] = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    ${downgrades if downgrades else "pass"}

--- a/alembic/versions/0001_create_portfolio_chunks.py
+++ b/alembic/versions/0001_create_portfolio_chunks.py
@@ -1,0 +1,47 @@
+"""create portfolio_chunks table
+
+Revision ID: 0001
+Revises:
+Create Date: 2026-05-16
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from pgvector.sqlalchemy import Vector
+
+revision = "0001"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "portfolio_chunks",
+        sa.Column("id", sa.UUID(), primary_key=True),
+        sa.Column("pdf_id", sa.String(), nullable=False),
+        sa.Column("section_title", sa.String(), nullable=False),
+        sa.Column("content", sa.String(), nullable=False),
+        sa.Column("embedding", Vector(1536), nullable=True),
+        sa.Column("section_type", sa.String(), nullable=False),
+        sa.Column("page", sa.Integer(), nullable=False),
+        sa.Column("order", sa.Integer(), nullable=False),
+        sa.Column("parent_title", sa.String(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+    op.create_index("ix_portfolio_chunks_pdf_id", "portfolio_chunks", ["pdf_id"])
+    op.execute(
+        "CREATE INDEX ON portfolio_chunks USING hnsw (embedding vector_cosine_ops)"
+    )
+    op.execute(
+        "CREATE INDEX ON portfolio_chunks USING gin (to_tsvector('english', content))"
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("portfolio_chunks")

--- a/app/models/base.py
+++ b/app/models/base.py
@@ -1,0 +1,5 @@
+from sqlalchemy.orm import DeclarativeBase
+
+
+class Base(DeclarativeBase):
+    pass

--- a/app/models/portfolio_chunk.py
+++ b/app/models/portfolio_chunk.py
@@ -1,0 +1,25 @@
+import uuid
+from datetime import datetime
+
+from pgvector.sqlalchemy import Vector
+from sqlalchemy import DateTime, Integer, String, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base
+
+
+class PortfolioChunk(Base):
+    __tablename__ = "portfolio_chunks"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    pdf_id: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    section_title: Mapped[str] = mapped_column(String, nullable=False)
+    content: Mapped[str] = mapped_column(String, nullable=False)
+    embedding: Mapped[list[float] | None] = mapped_column(Vector(1536), nullable=True)
+    section_type: Mapped[str] = mapped_column(String, nullable=False)
+    page: Mapped[int] = mapped_column(Integer, nullable=False)
+    order: Mapped[int] = mapped_column(Integer, nullable=False)
+    parent_title: Mapped[str | None] = mapped_column(String, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "google-generativeai>=0.8.0",
     "docling>=2.0.0",
     "python-dotenv>=1.0.0",
+    "alembic>=1.13.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,15 +1,16 @@
 import pytest
-from app.core.config import Settings
+from app.core.config import get_settings, Settings
 
 
 @pytest.fixture
 def test_settings() -> Settings:
+    real = get_settings()
     return Settings(
-        postgres_user="passfolio",
-        postgres_password="passfolio",
-        postgres_db="passfolio_db",
-        postgres_host="localhost",
-        postgres_port=5432,
+        postgres_user=real.postgres_user,
+        postgres_password=real.postgres_password,
+        postgres_db=real.postgres_db,
+        postgres_host=real.postgres_host,
+        postgres_port=real.postgres_port,
         openai_api_key="sk-test",
         gemini_api_key="gm-test",
     )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,108 @@
+import uuid
+
+import pytest
+from sqlalchemy import text
+
+from app.db.session import make_session_factory
+from app.models.portfolio_chunk import PortfolioChunk
+
+
+@pytest.mark.asyncio
+async def test_portfolio_chunk_table_exists(test_settings):
+    """portfolio_chunks 테이블이 DB에 존재하는지 확인 (alembic upgrade head 필요)."""
+    SessionLocal = make_session_factory(
+        test_settings.database_url, connect_args={"ssl": False}
+    )
+    async with SessionLocal() as session:
+        result = await session.execute(
+            text(
+                "SELECT table_name FROM information_schema.tables "
+                "WHERE table_schema = 'public' AND table_name = 'portfolio_chunks'"
+            )
+        )
+        row = result.fetchone()
+    assert row is not None, "portfolio_chunks table not found — run: alembic upgrade head"
+
+
+@pytest.mark.asyncio
+async def test_portfolio_chunk_insert_and_retrieve(test_settings):
+    """PortfolioChunk 행 삽입 후 조회 (embedding=None 허용)."""
+    SessionLocal = make_session_factory(
+        test_settings.database_url, connect_args={"ssl": False}
+    )
+    chunk_id = uuid.uuid4()
+    async with SessionLocal() as session:
+        chunk = PortfolioChunk(
+            id=chunk_id,
+            pdf_id="test-pdf-001",
+            section_title="프로젝트 경험",
+            content="FastAPI 기반 백엔드 서버를 개발했습니다.",
+            embedding=None,
+            section_type="experience",
+            page=1,
+            order=0,
+            parent_title=None,
+        )
+        session.add(chunk)
+        await session.commit()
+
+    async with SessionLocal() as session:
+        result = await session.execute(
+            text("SELECT pdf_id, section_title, section_type FROM portfolio_chunks WHERE id = :id"),
+            {"id": str(chunk_id)},
+        )
+        row = result.fetchone()
+
+    assert row is not None
+    assert row[0] == "test-pdf-001"
+    assert row[1] == "프로젝트 경험"
+    assert row[2] == "experience"
+
+    async with SessionLocal() as session:
+        await session.execute(
+            text("DELETE FROM portfolio_chunks WHERE id = :id"), {"id": str(chunk_id)}
+        )
+        await session.commit()
+
+
+@pytest.mark.asyncio
+async def test_portfolio_chunk_embedding_dimension(test_settings):
+    """Vector(1536) 임베딩 저장 및 조회 정확도 검증."""
+    SessionLocal = make_session_factory(
+        test_settings.database_url, connect_args={"ssl": False}
+    )
+    embedding = [0.1] * 1536
+    chunk_id = uuid.uuid4()
+
+    async with SessionLocal() as session:
+        chunk = PortfolioChunk(
+            id=chunk_id,
+            pdf_id="test-pdf-embed",
+            section_title="기술 스택",
+            content="Python, FastAPI, PostgreSQL을 사용합니다.",
+            embedding=embedding,
+            section_type="skill",
+            page=2,
+            order=1,
+            parent_title=None,
+        )
+        session.add(chunk)
+        await session.commit()
+
+    async with SessionLocal() as session:
+        result = await session.execute(
+            text(
+                "SELECT array_length(embedding::real[], 1) FROM portfolio_chunks WHERE id = :id"
+            ),
+            {"id": str(chunk_id)},
+        )
+        row = result.fetchone()
+
+    assert row is not None
+    assert row[0] == 1536
+
+    async with SessionLocal() as session:
+        await session.execute(
+            text("DELETE FROM portfolio_chunks WHERE id = :id"), {"id": str(chunk_id)}
+        )
+        await session.commit()


### PR DESCRIPTION
## 작업 내용

- `PortfolioChunk` SQLAlchemy 모델 추가 (`Vector(1536)`, pgvector)
- Alembic async 환경 세팅 및 `0001_create_portfolio_chunks` 마이그레이션
  - HNSW 인덱스 (cosine similarity), GIN 인덱스 (full-text search)
- `tests/conftest.py` 픽스처를 `.env` 실제 DB 설정 기반으로 수정
- `tests/test_models.py` 추가 (테이블 존재, 행 CRUD, Vector(1536) 차원 검증)

## 실행 방법

```bash
docker compose up -d
alembic upgrade head
pytest tests/test_models.py -v
```