### PR TITLE
Feat/#21 임베딩 및 db 저장

### DIFF
--- a/app/domain/retrieval/bm25_store.py
+++ b/app/domain/retrieval/bm25_store.py
@@ -1,0 +1,14 @@
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+async def gin_index_exists(session: AsyncSession) -> bool:
+    """portfolio_chunks.content GIN 인덱스 존재 여부 확인."""
+    result = await session.execute(
+        text(
+            "SELECT 1 FROM pg_indexes "
+            "WHERE tablename = 'portfolio_chunks' "
+            "AND indexdef LIKE '%to_tsvector%'"
+        )
+    )
+    return result.fetchone() is not None

--- a/app/domain/retrieval/embedder.py
+++ b/app/domain/retrieval/embedder.py
@@ -1,0 +1,14 @@
+from openai import AsyncOpenAI
+
+from app.core.config import get_settings
+
+
+async def embed(texts: list[str]) -> list[list[float]]:
+    """plain_text 리스트 → 1536차원 벡터 리스트."""
+    client = AsyncOpenAI(api_key=get_settings().openai_api_key)
+    resp = await client.embeddings.create(
+        model="text-embedding-3-small",
+        input=texts,
+        dimensions=1536,
+    )
+    return [item.embedding for item in resp.data]

--- a/app/domain/retrieval/schemas.py
+++ b/app/domain/retrieval/schemas.py
@@ -1,0 +1,11 @@
+import uuid
+from dataclasses import dataclass
+
+from app.domain.pdf.schemas import PdfSection
+
+
+@dataclass
+class EmbeddedSection:
+    section: PdfSection
+    embedding: list[float]
+    chunk_id: uuid.UUID

--- a/app/domain/retrieval/vector_store.py
+++ b/app/domain/retrieval/vector_store.py
@@ -1,0 +1,29 @@
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.domain.pdf.schemas import PdfSection
+from app.models.portfolio_chunk import PortfolioChunk
+
+
+async def upsert(
+    pdf_id: str,
+    sections: list[PdfSection],
+    embeddings: list[list[float]],
+    session: AsyncSession,
+) -> list[PortfolioChunk]:
+    """섹션 + 임베딩 → portfolio_chunks 테이블에 저장."""
+    chunks = [
+        PortfolioChunk(
+            pdf_id=pdf_id,
+            section_title=section.section_title,
+            content=section.plain_text,
+            embedding=embedding,
+            section_type=section.section_type,
+            page=section.page,
+            order=section.order,
+            parent_title=section.parent_title,
+        )
+        for section, embedding in zip(sections, embeddings)
+    ]
+    session.add_all(chunks)
+    await session.commit()
+    return chunks

--- a/tests/domain/test_retrieval.py
+++ b/tests/domain/test_retrieval.py
@@ -1,0 +1,104 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy import text
+
+from app.db.session import make_session_factory
+from app.domain.retrieval.bm25_store import gin_index_exists
+from app.domain.retrieval.embedder import embed
+from app.domain.retrieval.vector_store import upsert
+
+_PDF_ID = "test-retrieval-001"
+_DIMS = 1536
+
+
+def _fake_embedding(dim: int = _DIMS) -> list[float]:
+    return [0.1] * dim
+
+
+def _mock_openai_response(n: int) -> MagicMock:
+    resp = MagicMock()
+    resp.data = [MagicMock(embedding=_fake_embedding()) for _ in range(n)]
+    return resp
+
+
+# ── embedder ──────────────────────────────────────────────────────────────────
+
+async def test_embed_returns_correct_shape():
+    texts = ["안녕하세요", "Python FastAPI", "pgvector 연동", "임베딩 테스트", "검색"]
+    with patch("app.domain.retrieval.embedder.AsyncOpenAI") as MockClient:
+        MockClient.return_value.embeddings.create = AsyncMock(
+            return_value=_mock_openai_response(len(texts))
+        )
+        result = await embed(texts)
+    assert len(result) == len(texts)
+
+
+async def test_embed_each_vector_has_1536_dims():
+    texts = ["FastAPI", "PostgreSQL"]
+    with patch("app.domain.retrieval.embedder.AsyncOpenAI") as MockClient:
+        MockClient.return_value.embeddings.create = AsyncMock(
+            return_value=_mock_openai_response(len(texts))
+        )
+        result = await embed(texts)
+    assert all(len(vec) == _DIMS for vec in result)
+
+
+# ── vector_store ──────────────────────────────────────────────────────────────
+
+async def test_upsert_stores_chunks(test_settings, mock_sections):
+    SessionLocal = make_session_factory(
+        test_settings.database_url, connect_args={"ssl": False}
+    )
+    embeddings = [_fake_embedding() for _ in mock_sections]
+    async with SessionLocal() as session:
+        chunks = await upsert(_PDF_ID, mock_sections, embeddings, session)
+    assert len(chunks) == len(mock_sections)
+    async with SessionLocal() as session:
+        await session.execute(
+            text("DELETE FROM portfolio_chunks WHERE pdf_id = :pid"), {"pid": _PDF_ID}
+        )
+        await session.commit()
+
+
+async def test_upsert_chunk_has_embedding(test_settings, mock_sections):
+    SessionLocal = make_session_factory(
+        test_settings.database_url, connect_args={"ssl": False}
+    )
+    embeddings = [_fake_embedding() for _ in mock_sections]
+    async with SessionLocal() as session:
+        chunks = await upsert(_PDF_ID, mock_sections, embeddings, session)
+    assert all(chunk.embedding is not None for chunk in chunks)
+    assert all(len(chunk.embedding) == _DIMS for chunk in chunks)
+    async with SessionLocal() as session:
+        await session.execute(
+            text("DELETE FROM portfolio_chunks WHERE pdf_id = :pid"), {"pid": _PDF_ID}
+        )
+        await session.commit()
+
+
+async def test_upsert_chunk_content_matches_plain_text(test_settings, mock_sections):
+    SessionLocal = make_session_factory(
+        test_settings.database_url, connect_args={"ssl": False}
+    )
+    embeddings = [_fake_embedding() for _ in mock_sections]
+    async with SessionLocal() as session:
+        chunks = await upsert(_PDF_ID, mock_sections, embeddings, session)
+    for chunk, section in zip(chunks, mock_sections):
+        assert chunk.content == section.plain_text
+    async with SessionLocal() as session:
+        await session.execute(
+            text("DELETE FROM portfolio_chunks WHERE pdf_id = :pid"), {"pid": _PDF_ID}
+        )
+        await session.commit()
+
+
+# ── bm25_store ────────────────────────────────────────────────────────────────
+
+async def test_gin_index_exists(test_settings):
+    SessionLocal = make_session_factory(
+        test_settings.database_url, connect_args={"ssl": False}
+    )
+    async with SessionLocal() as session:
+        exists = await gin_index_exists(session)
+    assert exists is True


### PR DESCRIPTION
## 작업 내용

* `embedder.py`

  * OpenAI `text-embedding-3-small` 기반 임베딩 생성
  * `section.plain_text` 기준 배치 임베딩 처리

* `vector_store.py`

  * `portfolio_chunks` 테이블 upsert 구현
  * pgvector 임베딩 저장 로직 추가
  * 외부 session 주입 방식 적용

* `bm25_store.py`

  * PostgreSQL Full-Text 기반 GIN 인덱스 확인 로직 추가

* `schemas.py`

  * `EmbeddedSection` dataclass 추가

---

## 테스트

* OpenAI mock 기반 임베딩 테스트
* pgvector 실제 DB upsert 테스트
* GIN 인덱스 존재 확인 테스트
