### PR TITLE
Feat/#23 유사 섹션 하이브리드 검색 구현

### DIFF
--- a/app/domain/retrieval/schemas.py
+++ b/app/domain/retrieval/schemas.py
@@ -9,3 +9,16 @@ class EmbeddedSection:
     section: PdfSection
     embedding: list[float]
     chunk_id: uuid.UUID
+
+
+@dataclass
+class SearchResult:
+    chunk_id: uuid.UUID
+    pdf_id: str
+    section_title: str
+    content: str
+    section_type: str
+    score: float
+    page: int
+    order: int
+    parent_title: str | None

--- a/app/domain/retrieval/searcher.py
+++ b/app/domain/retrieval/searcher.py
@@ -1,0 +1,104 @@
+import uuid
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.domain.retrieval.embedder import embed
+from app.domain.retrieval.schemas import SearchResult
+
+_RRF_K = 60
+
+
+def _row_to_result(row, score: float) -> SearchResult:
+    return SearchResult(
+        chunk_id=row.id,
+        pdf_id=row.pdf_id,
+        section_title=row.section_title,
+        content=row.content,
+        section_type=row.section_type,
+        score=score,
+        page=row.page,
+        order=row.order,
+        parent_title=row.parent_title,
+    )
+
+
+async def vector_search(
+    embedding: list[float],
+    pdf_id: str,
+    session: AsyncSession,
+    top_k: int = 20,
+) -> list[SearchResult]:
+    """pgvector 코사인 유사도 검색."""
+    rows = await session.execute(
+        text(
+            "SELECT *, 1 - (embedding <=> CAST(:vec AS vector)) AS score "
+            "FROM portfolio_chunks "
+            "WHERE pdf_id = :pdf_id "
+            "ORDER BY embedding <=> CAST(:vec AS vector) "
+            "LIMIT :top_k"
+        ),
+        {"vec": str(embedding), "pdf_id": pdf_id, "top_k": top_k},
+    )
+    return [_row_to_result(r, r.score) for r in rows.fetchall()]
+
+
+async def bm25_search(
+    query_text: str,
+    pdf_id: str,
+    session: AsyncSession,
+    top_k: int = 20,
+) -> list[SearchResult]:
+    """PostgreSQL Full-Text 검색 (한국어 포함 simple 딕셔너리 사용)."""
+    rows = await session.execute(
+        text(
+            "SELECT *, ts_rank_cd("
+            "  to_tsvector('simple', content),"
+            "  plainto_tsquery('simple', :query)"
+            ") AS score "
+            "FROM portfolio_chunks "
+            "WHERE pdf_id = :pdf_id "
+            "  AND to_tsvector('simple', content) @@ plainto_tsquery('simple', :query) "
+            "ORDER BY score DESC "
+            "LIMIT :top_k"
+        ),
+        {"query": query_text, "pdf_id": pdf_id, "top_k": top_k},
+    )
+    return [_row_to_result(r, r.score) for r in rows.fetchall()]
+
+
+def rrf_merge(
+    vector_results: list[SearchResult],
+    bm25_results: list[SearchResult],
+    top_k: int = 5,
+) -> list[SearchResult]:
+    """Reciprocal Rank Fusion으로 두 결과 리스트를 결합."""
+    scores: dict[uuid.UUID, float] = {}
+    sources: dict[uuid.UUID, SearchResult] = {}
+
+    for rank, result in enumerate(vector_results):
+        scores[result.chunk_id] = scores.get(result.chunk_id, 0.0) + 1.0 / (_RRF_K + rank + 1)
+        sources[result.chunk_id] = result
+
+    for rank, result in enumerate(bm25_results):
+        scores[result.chunk_id] = scores.get(result.chunk_id, 0.0) + 1.0 / (_RRF_K + rank + 1)
+        sources[result.chunk_id] = result
+
+    ranked = sorted(scores.keys(), key=lambda cid: scores[cid], reverse=True)[:top_k]
+    return [
+        SearchResult(**{**sources[cid].__dict__, "score": scores[cid]})
+        for cid in ranked
+    ]
+
+
+async def hybrid_search(
+    query_text: str,
+    pdf_id: str,
+    session: AsyncSession,
+    top_k: int = 5,
+) -> list[SearchResult]:
+    """vector + BM25 하이브리드 검색 → RRF 결합."""
+    embedding = (await embed([query_text]))[0]
+    vec_results = await vector_search(embedding, pdf_id, session, top_k=top_k * 4)
+    bm25_results = await bm25_search(query_text, pdf_id, session, top_k=top_k * 4)
+    return rrf_merge(vec_results, bm25_results, top_k=top_k)

--- a/tests/domain/test_retrieval.py
+++ b/tests/domain/test_retrieval.py
@@ -6,6 +6,8 @@ from sqlalchemy import text
 from app.db.session import make_session_factory
 from app.domain.retrieval.bm25_store import gin_index_exists
 from app.domain.retrieval.embedder import embed
+from app.domain.retrieval.searcher import bm25_search, hybrid_search, rrf_merge, vector_search
+from app.domain.retrieval.schemas import SearchResult
 from app.domain.retrieval.vector_store import upsert
 
 _PDF_ID = "test-retrieval-001"
@@ -91,6 +93,67 @@ async def test_upsert_chunk_content_matches_plain_text(test_settings, mock_secti
             text("DELETE FROM portfolio_chunks WHERE pdf_id = :pid"), {"pid": _PDF_ID}
         )
         await session.commit()
+
+
+# ── searcher ─────────────────────────────────────────────────────────────────
+
+_SEARCH_PDF_ID = "test-searcher-001"
+
+
+@pytest.fixture
+async def stored_chunks(test_settings, mock_sections):
+    SessionLocal = make_session_factory(
+        test_settings.database_url, connect_args={"ssl": False}
+    )
+    embeddings = [_fake_embedding() for _ in mock_sections]
+    async with SessionLocal() as session:
+        await upsert(_SEARCH_PDF_ID, mock_sections, embeddings, session)
+    yield SessionLocal
+    async with SessionLocal() as session:
+        await session.execute(
+            text("DELETE FROM portfolio_chunks WHERE pdf_id = :pid"),
+            {"pid": _SEARCH_PDF_ID},
+        )
+        await session.commit()
+
+
+async def test_vector_search_returns_results(stored_chunks):
+    async with stored_chunks() as session:
+        results = await vector_search(_fake_embedding(), _SEARCH_PDF_ID, session, top_k=3)
+    assert len(results) > 0
+    assert all(isinstance(r, SearchResult) for r in results)
+
+
+async def test_bm25_search_returns_results(stored_chunks):
+    async with stored_chunks() as session:
+        results = await bm25_search("Python FastAPI", _SEARCH_PDF_ID, session, top_k=3)
+    assert isinstance(results, list)
+
+
+async def test_rrf_merge_combines_and_deduplicates():
+    import uuid
+    def _sr(chunk_id, score):
+        return SearchResult(
+            chunk_id=chunk_id, pdf_id="p", section_title="t",
+            content="c", section_type="general", score=score,
+            page=1, order=0, parent_title=None,
+        )
+    uid_a, uid_b, uid_c = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    vec = [_sr(uid_a, 0.9), _sr(uid_b, 0.8), _sr(uid_c, 0.7)]
+    bm25 = [_sr(uid_b, 0.95), _sr(uid_a, 0.85)]
+    merged = rrf_merge(vec, bm25, top_k=3)
+    ids = [r.chunk_id for r in merged]
+    assert len(ids) == len(set(ids)), "중복 chunk_id 없어야 함"
+    assert len(merged) <= 3
+
+
+async def test_hybrid_search_returns_results(stored_chunks):
+    with patch("app.domain.retrieval.searcher.embed") as mock_embed:
+        mock_embed.return_value = [_fake_embedding()]
+        async with stored_chunks() as session:
+            results = await hybrid_search("Python FastAPI", _SEARCH_PDF_ID, session, top_k=3)
+    assert isinstance(results, list)
+    assert all(isinstance(r, SearchResult) for r in results)
 
 
 # ── bm25_store ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## 작업 내용

* `SearchResult` dataclass 추가
* `searcher.py` 구현

  * `vector_search()` — pgvector cosine similarity search
  * `bm25_search()` — PostgreSQL Full-Text(BM25) 기반 키워드 검색
  * `rrf_merge()` — RRF 기반 검색 결과 병합 및 중복 제거
  * `hybrid_search()` — vector + BM25 hybrid retrieval

---

## 주요 구현 사항

* pgvector `<=>` 연산자 기반 cosine similarity 검색 적용
* PostgreSQL `ts_rank_cd` 기반 BM25 검색 구현
* `simple` dictionary 사용으로 한국어 키워드 검색 대응
* RRF(k=60) 기반 hybrid ranking 적용
* `AsyncSession` 외부 주입 방식 적용

---

## 테스트

* vector search 결과 검증
* BM25 full-text 검색 검증
* RRF 병합 및 deduplicate 검증
* hybrid search 전체 파이프라인 검증

