### PR TITLE
Refactor/#46 rag 파이프라인 변경

### DIFF
--- a/app/api/v1/cover_letter.py
+++ b/app/api/v1/cover_letter.py
@@ -4,11 +4,13 @@ from fastapi import APIRouter, BackgroundTasks
 
 from app.jobs.store import create_job
 from app.schemas.cover_letter import (
+    FromCoverLetterRequest,
     FromPortfolioRequest,
     ToCoverLetterRequest,
 )
 from app.schemas.job import JobStatusResponse
 from app.services.cover_letter import (
+    run_cover_letter_from_pdf_task,
     run_cover_letter_to_portfolio_task,
     run_portfolio_to_cover_letter_task,
 )
@@ -39,6 +41,21 @@ async def cover_letter_to_portfolio(
     job = create_job()
     background_tasks.add_task(
         run_cover_letter_to_portfolio_task,
+        job_id=str(job.job_id),
+        pdf_s3_url=req.pdfS3Url,
+        user_id=req.userId,
+    )
+    return JobStatusResponse(job_id=str(job.job_id), status=job.status)
+
+
+@router.post("/from-pdf", response_model=JobStatusResponse)
+async def cover_letter_from_pdf(
+    req: FromCoverLetterRequest,
+    background_tasks: BackgroundTasks,
+) -> JobStatusResponse:
+    job = create_job()
+    background_tasks.add_task(
+        run_cover_letter_from_pdf_task,
         job_id=str(job.job_id),
         pdf_s3_url=req.pdfS3Url,
         user_id=req.userId,

--- a/app/api/v1/cover_letter.py
+++ b/app/api/v1/cover_letter.py
@@ -1,32 +1,19 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, BackgroundTasks, HTTPException
+from fastapi import APIRouter, BackgroundTasks
 
-from app.jobs.store import create_job, get_job
+from app.jobs.store import create_job
 from app.schemas.cover_letter import (
-    CoverLetterImproveRequest,
-    CoverLetterImproveResponse,
     FromPortfolioRequest,
     ToCoverLetterRequest,
 )
 from app.schemas.job import JobStatusResponse
 from app.services.cover_letter import (
-    rag_cover_letter,
     run_cover_letter_to_portfolio_task,
     run_portfolio_to_cover_letter_task,
 )
 
 router = APIRouter(prefix="/cover-letter", tags=["cover-letter"])
-
-
-@router.post("/improve", response_model=CoverLetterImproveResponse)
-def cover_letter_improve(req: CoverLetterImproveRequest) -> CoverLetterImproveResponse:
-    result = rag_cover_letter(
-        query=req.text,
-        char_limit=req.char_limit,
-        section=req.section,
-    )
-    return CoverLetterImproveResponse(**result)
 
 
 @router.post("/from-portfolio", response_model=JobStatusResponse)

--- a/app/api/v1/portfolio.py
+++ b/app/api/v1/portfolio.py
@@ -4,16 +4,10 @@ from fastapi import APIRouter, BackgroundTasks
 
 from app.jobs.store import create_job
 from app.schemas.job import JobStatusResponse
-from app.schemas.portfolio import FromPdfRequest, PortfolioImproveRequest, PortfolioImproveResponse
-from app.services.portfolio import rag_portfolio, run_portfolio_from_pdf_task
+from app.schemas.portfolio import FromPdfRequest
+from app.services.portfolio import run_portfolio_from_pdf_task
 
 router = APIRouter(prefix="/portfolio", tags=["portfolio"])
-
-
-@router.post("/improve", response_model=PortfolioImproveResponse)
-def portfolio_improve(req: PortfolioImproveRequest) -> PortfolioImproveResponse:
-    result = rag_portfolio(query=req.query, img_context=req.img_context)
-    return PortfolioImproveResponse(**result)
 
 
 @router.post("/from-pdf", response_model=JobStatusResponse)

--- a/app/schemas/cover_letter.py
+++ b/app/schemas/cover_letter.py
@@ -3,20 +3,6 @@ from __future__ import annotations
 from pydantic import BaseModel
 
 
-class CoverLetterImproveRequest(BaseModel):
-    section:      str
-    text:         str
-    job_position: str = ""
-    career:       str = ""
-    char_limit:   int | None = None
-
-
-class CoverLetterImproveResponse(BaseModel):
-    improved:  str
-    reasoning: str
-    changes:   list[str]
-
-
 class FromPortfolioRequest(BaseModel):
     pdfS3Url:     str
     userId:       int | None = None

--- a/app/schemas/cover_letter.py
+++ b/app/schemas/cover_letter.py
@@ -15,3 +15,8 @@ class ToCoverLetterRequest(BaseModel):
     userId:       int | None = None
     job_position: str = ""
     career:       str = ""
+
+
+class FromCoverLetterRequest(BaseModel):
+    pdfS3Url: str
+    userId:   int | None = None

--- a/app/schemas/portfolio.py
+++ b/app/schemas/portfolio.py
@@ -3,17 +3,6 @@ from __future__ import annotations
 from pydantic import BaseModel
 
 
-class PortfolioImproveRequest(BaseModel):
-    query:       str
-    img_context: str = ""
-
-
-class PortfolioImproveResponse(BaseModel):
-    improved:  str
-    reasoning: str
-    changes:   list[str]
-
-
 class FromPdfRequest(BaseModel):
     pdfS3Url: str
     userId: int | None = None

--- a/app/services/cover_letter.py
+++ b/app/services/cover_letter.py
@@ -222,6 +222,56 @@ def rag_cover_letter(
 
 
 # ───────────────────────────────────────────────────────────────
+# RAG-1: 자소서 PDF → 섹션별 개선
+# ───────────────────────────────────────────────────────────────
+
+def run_cover_letter_from_pdf(pdf_s3_url: str, user_id: int | None = None, top_k: int = TOP_K_FINAL) -> dict:
+    from docling.document_converter import DocumentConverter
+    from app.chunkers import cover_letter as cl_chunker
+    from app.evaluators.cover_letter import evaluate_comparison, parse_char_limit
+    from app.exporters.cover_letter_pdf import save_cl_improvement_pdf
+
+    tmp_path = download_pdf_to_temp(pdf_s3_url)
+    out_pdf  = make_output_path("cl_improvement")
+    try:
+        converter = DocumentConverter()
+        text      = converter.convert(tmp_path).document.export_to_text()
+
+        print(f"  [RAG-1] 자소서 청킹 중...")
+        chunks = cl_chunker.chunk(text, source="cover_letter")
+        print(f"  [RAG-1] 청킹 완료: {len(chunks)}개 청크")
+
+        results = []
+        for idx, c in enumerate(chunks):
+            section    = c.get("section", "")
+            category   = c.get("category", "")
+            char_limit = parse_char_limit(section)
+
+            print(f"  [RAG-1] [{idx+1}/{len(chunks)}] RAG 개선: {section} / {category}")
+            result      = rag_cover_letter(c["text"], top_k=top_k, char_limit=char_limit, section=section)
+            eval_result = evaluate_comparison(c["text"], result["improved"], char_limit=char_limit, question=section)
+
+            results.append({
+                "section":     section,
+                "category":    category,
+                "original":    c["text"],
+                "improved":    result["improved"],
+                "reasoning":   result["reasoning"],
+                "changes":     result["changes"],
+                "eval_before": eval_result["before"]["weighted"],
+                "eval_after":  eval_result["after"]["weighted"],
+                "eval_delta":  eval_result["delta"],
+                "eval_detail": eval_result["per_category"],
+            })
+
+        save_cl_improvement_pdf(results, out_pdf)
+        output_s3_url = upload_pdf_file(out_pdf, user_id)
+        return {"sections": results, "outputPdfS3Url": output_s3_url}
+    finally:
+        cleanup_files(tmp_path, out_pdf)
+
+
+# ───────────────────────────────────────────────────────────────
 # 포트폴리오 → 자소서 생성 헬퍼
 # ───────────────────────────────────────────────────────────────
 
@@ -508,4 +558,17 @@ async def run_cover_letter_to_portfolio_task(
         job_id,
         lambda: run_cover_letter_to_portfolio(pdf_s3_url, user_id=user_id, top_k=top_k),
         tag="RAG-5",
+    )
+
+
+async def run_cover_letter_from_pdf_task(
+    job_id: str,
+    pdf_s3_url: str,
+    user_id: int | None = None,
+    top_k: int = TOP_K_FINAL,
+) -> None:
+    run_job_pipeline(
+        job_id,
+        lambda: run_cover_letter_from_pdf(pdf_s3_url, user_id=user_id, top_k=top_k),
+        tag="RAG-1",
     )


### PR DESCRIPTION
# 작업 배경

현재 Passfolio AI 서버는 텍스트 기반 입력과 PDF 기반 입력이 혼재되어 있으며,
동기/비동기 처리 방식 또한 분리되어 있음.

이로 인해:

- orchestration 복잡도 증가
- FE 처리 흐름 이원화
- pipeline 재사용성 저하
- 유지보수 비용 증가

문제가 발생하고 있다.

기존 구조:

| RAG | 입력 | 출력 | 처리 방식 |
|-----|------|------|------|
| RAG-1 | 자소서 텍스트 | 개선된 자소서 | 동기 |
| RAG-2 | 포트폴리오 PDF (S3) | 자소서 PDF (S3) | 비동기 |
| RAG-3 | 포트폴리오 텍스트 | 개선된 포트폴리오 | 동기 |
| RAG-4 | 포트폴리오 PDF (S3) | 개선된 포트폴리오 PDF (S3) | 비동기 |
| RAG-5 | 자소서 PDF (S3) | 포트폴리오 PDF (S3) | 비동기 |

이번 PR에서는 모든 RAG 파이프라인을:

```text
PDF(S3) 입력
→ AI 처리
→ PDF(S3) 출력
```

구조로 통일하기 위한 작업을 진행한.

---

# 변경 사항

## 1. 신규 RAG-1 추가

### 자소서 PDF → 개선된 자소서 PDF

신규 pipeline 추가:

```python
run_cover_letter_from_pdf()
run_cover_letter_from_pdf_task()
```

### 처리 흐름

```text
1. S3에서 PDF 다운로드
2. cover letter chunking
3. 각 section에 rag_cover_letter() 적용
4. evaluator 수행
5. output PDF 생성
6. S3 업로드
7. outputPdfS3Url 반환
```

### 재사용한 기존 로직

- rag_cover_letter()
- cover letter chunker
- evaluator
- 기존 PDF exporter

---

## 2. deprecated endpoint 제거

제거 endpoint:

```http
POST /api/v1/cover-letter/improve
POST /api/v1/portfolio/improve
```

텍스트 기반 입력 흐름 제거.

---

## 3. 신규 endpoint 추가

추가 endpoint:

```http
POST /api/v1/cover-letter/from-pdf
```

### 처리 방식

- BackgroundTasks 기반
- Job polling 방식 유지

---

# 변경 후 RAG 구조

| RAG | 입력 | 출력 | 처리 방식 |
|-----|------|------|------|
| RAG-1 | 자소서 PDF (S3) | 개선된 자소서 PDF (S3) | 비동기 |
| RAG-2 | 자소서 PDF (S3) | 개선된 포트폴리오 PDF (S3) | 비동기 |
| RAG-3 | 포트폴리오 PDF (S3) | 개선된 자소서 PDF (S3) | 비동기 |
| RAG-4 | 포트폴리오 PDF (S3) | 개선된 포트폴리오 PDF (S3) | 비동기 |

---

# 테스트

## 신규 RAG-1 검증

- [ ] 긴 자소서 PDF
- [ ] 짧은 자소서 PDF
- [ ] OCR 품질 낮은 PDF
- [ ] 여러 section 포함 PDF
- [ ] output PDF 정상 생성
- [ ] outputPdfS3Url 정상 반환

---

## Regression 검증

- [ ] 포트폴리오 → 자소서
- [ ] 자소서 → 포트폴리오
- [ ] 포트폴리오 개선
- [ ] retrieval 품질 유지
- [ ] hallucination 증가 없음
- [ ] 숫자 보존 유지

---
