### PR TITLE
refactor: boto3 다운로드를 Presigned URL + requests.get() 방식으로 교체

### DIFF
--- a/app/services/s3_client.py
+++ b/app/services/s3_client.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import uuid
-from urllib.parse import urlparse
 
 import boto3
+import requests
 
 from app.core.config import get_settings
 
@@ -17,23 +17,10 @@ def _get_boto_client():
     return boto3.client("s3", **kwargs)
 
 
-def _parse_s3_url(url: str) -> tuple[str, str]:
-    """S3 URL을 (bucket, key) 튜플로 파싱."""
-    parsed = urlparse(url)
-    path = parsed.path.lstrip("/")
-    host = parsed.hostname or ""
-    if host.startswith("s3"):
-        # path-style: https://s3.region.amazonaws.com/bucket/key
-        parts = path.split("/", 1)
-        return parts[0], parts[1] if len(parts) > 1 else ""
-    # virtual-hosted: https://bucket.s3.region.amazonaws.com/key
-    return host.split(".")[0], path
-
-
-def download_pdf(s3_url: str) -> bytes:
-    bucket, key = _parse_s3_url(s3_url)
-    resp = _get_boto_client().get_object(Bucket=bucket, Key=key)
-    return resp["Body"].read()
+def download_pdf(url: str) -> bytes:
+    resp = requests.get(url, timeout=30)
+    resp.raise_for_status()
+    return resp.content
 
 
 def upload_pdf(data: bytes, user_id: int | None = None) -> str:


### PR DESCRIPTION
# 배경

현재 AI 서버:

```text
BE → AI
pdfS3Url 전달
```

구조를 사용

현재 구조:

- FE/BE가 사용하는 원본 파일 S3 Bucket
- AI가 사용하는 결과 저장용 S3 Bucket

이 서로 다른 상태

현재 AI 서버는 boto3 기반 GetObject 방식으로 원본 PDF를 다운로드하고 있으며,
이 경우 AI IAM이 FE/BE 원본 Bucket에 대한 GetObject 권한을 가져야 함.

이 구조는:

- cross-bucket IAM 관리 필요
- 서비스 간 coupling 증가
- bucket 정책 복잡도 증가

문제가 발생

---

# 목표

AI 서버가 FE/BE Bucket IAM 권한 없이도
원본 PDF를 다운로드할 수 있도록 구조를 변경

이를 위해:

```text
Presigned URL 기반 다운로드 방식
```

으로 변경

---

# 변경 전 구조

```text
[FE]
    ↓ 업로드

[BE]
    ↓
원본 PDF → FE/BE S3 Bucket 저장
    ↓
일반 S3 URL 전달

[AI]
    ↓
boto3 GetObject()
    ↓
IAM 기반 다운로드
```

문제:
- AI가 FE/BE Bucket 접근 권한 필요
- cross-bucket IAM dependency 발생

---

# 변경 후 구조

```text
[FE]
    ↓ 업로드

[BE]
    ↓
원본 PDF → FE/BE S3 Bucket 저장
    ↓
Presigned URL 생성
    ↓
AI 서버 호출

[AI]
    ↓
requests.get()
    ↓
PDF 다운로드
    ↓
RAG 처리
    ↓
결과 PDF 생성
    ↓
AI Bucket 업로드
```

---

# 핵심 변경 사항

## 기존 방식

AI:

```python
boto3.get_object()
```

사용.

---

## 변경 후 방식

AI:

```python
requests.get()
```

사용.

즉:
- AWS IAM 인증 제거
- URL 기반 다운로드 방식 사용

---

# Presigned URL 설명

Presigned URL은:

```text
일정 시간 동안만 접근 가능한
임시 인증 URL
```

예:

```text
https://bucket.s3.amazonaws.com/...
?X-Amz-Signature=...
&X-Amz-Expires=300
```

특징:

- private S3 object 유지 가능
- AI IAM 권한 불필요
- 일정 시간 이후 자동 만료
- requests.get()으로 다운로드 가능

---

# BE(Spring Boot) 작업

## Presigned URL 생성

기존:

```text
일반 S3 URL 생성
```

→ 변경:

```text
Presigned URL 생성
```

---

# AI(FastAPI) 작업

## 기존 방식 제거

제거 대상:

```python
boto3.client("s3")
get_object()
download_file()
```

원본 PDF 다운로드 로직 제거.

---

## 신규 방식

추가:

```python
requests.get()
```

기반 다운로드 로직.

----

# 권한 구조 변경

## 기존

AI IAM 필요:

| Bucket | 권한 |
|---|---|
| FE/BE Bucket | GetObject |
| AI Bucket | PutObject |

---

## 변경 후

AI IAM:

| Bucket | 권한 |
|---|---|
| FE/BE Bucket | 불필요 |
| AI Bucket | PutObject |

즉:
- cross-bucket IAM 제거 가능
- AI IAM 단순화 가능

---

# 변경 대상

## BE

### 변경 필요

- Presigned URL 생성 로직 추가
- 기존 일반 S3 URL 반환 제거

---

## AI

### 변경 필요

- boto3 기반 원본 PDF 다운로드 제거
- requests.get() 기반 다운로드 추가

---

# 완료 조건

- AI가 FE/BE Bucket IAM 없이 다운로드 가능
- requests.get() 기반 PDF 다운로드 정상 동작
- 기존 RAG 품질 유지
- 기존 async pipeline 정상 동작
- outputPdfS3Url 정상 반환
- AI bucket upload 정상 동작