### PR TITLE
fix: dockerignore에서 sample 제외

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,8 +12,6 @@ __pycache__
 *.tar.*
 docs/
 tests/
-pdfsample/
-portfoliosample/
 app/output/
 output/*
 !output/bm25_cover_letters.pkl


### PR DESCRIPTION
도커에 샘플 데이터 추가