### PR TITLE
Refactor/#77 처리속도 지연 이슈 해결

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -23,18 +23,20 @@ class Settings(BaseSettings):
 
     @property
     def db_config(self) -> dict:
-        ctx = ssl.create_default_context()
-        ctx.check_hostname = False
-        ctx.verify_mode = ssl.CERT_NONE
-        return {
-            "host":        self.postgres_host,
-            "port":        self.postgres_port,
-            "database":    self.postgres_db,
-            "user":        self.postgres_user,
-            "password":    self.postgres_password,
-            "timeout":     10,
-            "ssl_context": ctx,
+        config: dict = {
+            "host":     self.postgres_host,
+            "port":     self.postgres_port,
+            "database": self.postgres_db,
+            "user":     self.postgres_user,
+            "password": self.postgres_password,
+            "timeout":  10,
         }
+        if self.postgres_host != "localhost":
+            ctx = ssl.create_default_context()
+            ctx.check_hostname = False
+            ctx.verify_mode = ssl.CERT_NONE
+            config["ssl_context"] = ctx
+        return config
 
     model_config = {"env_file": ".env", "extra": "ignore"}
 

--- a/app/services/_rag_utils.py
+++ b/app/services/_rag_utils.py
@@ -202,6 +202,9 @@ def _embed_query(text: str) -> list[float]:
 # BM25 검색
 # ───────────────────────────────────────────────────────────────
 
+_bm25_cache: dict[Path, dict] = {}
+
+
 def _bm25_search(
     query: str,
     bm25_path: Path,
@@ -210,8 +213,10 @@ def _bm25_search(
     job: str | None = None,
     career: str | None = None,
 ) -> list[tuple[str, float]]:
-    with open(bm25_path, "rb") as f:
-        data = pickle.load(f)
+    if bm25_path not in _bm25_cache:
+        with open(bm25_path, "rb") as f:
+            _bm25_cache[bm25_path] = pickle.load(f)
+    data = _bm25_cache[bm25_path]
     tokens = _tokenize_ko(query)
 
     sub_sections = data.get("sub_sections")

--- a/app/services/_rag_utils.py
+++ b/app/services/_rag_utils.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import os
 import pickle
 import re
+import threading
 import time
 from pathlib import Path
 
@@ -204,6 +205,26 @@ def _embed_query(text: str) -> list[float]:
 
 _bm25_cache: dict[Path, dict] = {}
 
+_db_local = threading.local()
+
+
+def _get_conn() -> pg8000.Connection:
+    conn = getattr(_db_local, "conn", None)
+    if conn is None:
+        _db_local.conn = pg8000.connect(**get_settings().db_config)
+        return _db_local.conn
+    try:
+        cur = conn.cursor()
+        cur.execute("SELECT 1")
+        cur.close()
+    except Exception:
+        try:
+            conn.close()
+        except Exception:
+            pass
+        _db_local.conn = pg8000.connect(**get_settings().db_config)
+    return _db_local.conn
+
 
 def _bm25_search(
     query: str,
@@ -251,7 +272,7 @@ def _vector_search(
     career: str | None = None,
 ) -> list[tuple[str, float]]:
     emb_str = "[" + ",".join(str(x) for x in query_emb) + "]"
-    conn = pg8000.connect(**get_settings().db_config)
+    conn = _get_conn()
     cur  = conn.cursor()
 
     fetch_k = top_k * 3 if (job or career) and table == "cover_letter_chunks" else top_k
@@ -272,7 +293,6 @@ def _vector_search(
     cur.close()
     if (job or career) and table == "cover_letter_chunks":
         rows = [(id_, s) for id_, s in rows if _cl_id_matches(id_, job, career)]
-    conn.close()
     return rows
 
 
@@ -302,12 +322,11 @@ def _fetch_chunks(ids: list[str], table: str, cols: list[str]) -> list[dict]:
         return []
     placeholders = ",".join(["%s"] * len(ids))
     col_str      = ", ".join(cols)
-    conn = pg8000.connect(**get_settings().db_config)
+    conn = _get_conn()
     cur  = conn.cursor()
     cur.execute(f"SELECT {col_str} FROM {table} WHERE id IN ({placeholders})", ids)
     rows       = [dict(zip(cols, row)) for row in cur.fetchall()]
     cur.close()
-    conn.close()
     id_to_row = {r["id"]: r for r in rows}
     return [id_to_row[id_] for id_ in ids if id_ in id_to_row]
 

--- a/app/services/cover_letter.py
+++ b/app/services/cover_letter.py
@@ -502,7 +502,7 @@ def run_cover_letter_to_portfolio(
 
         logger.info("[RAG-2] 자소서 청킹 중...")
         chunks = cl_chunker.chunk(text, "cover_letter")
-        logger.info("[RAG-2] 청킹 완료: %d개 청크 (코드분석: %s)", len(chunks), "있음" if code_analysis else "없음")
+        logger.info("[RAG-2] 청킹 완료: %d개 청크 (코드분석: %s)", len(chunks), "있음" if code_analyses else "없음")
 
         _EXCLUDE_CATEGORIES = {"지원동기", "입사포부", "취미", "사회이슈"}
         cats_found = [c.get("category", "") for c in chunks]

--- a/app/services/pdf_pipeline.py
+++ b/app/services/pdf_pipeline.py
@@ -7,6 +7,8 @@ import tempfile
 import uuid
 from typing import Callable
 
+import anyio
+
 from app.jobs.store import JobStatus, update_job
 from app.services._rag_utils import OUTPUT_DIR
 from app.services.s3_client import download_pdf, upload_pdf
@@ -56,7 +58,7 @@ async def run_job_pipeline(job_id: str, fn: Callable, tag: str = "") -> None:
     output_pdf_url: str | None = None
     error_message:  str | None = None
     try:
-        result         = fn()
+        result         = await anyio.to_thread.run_sync(fn)
         output_pdf_url = result.get("outputPdfS3Url")
         sections       = result.get("sections", [])
         logger.info("[%s][%s] Job 완료 (DONE): %d개 섹션", tag, job_id, len(sections))

--- a/app/services/portfolio.py
+++ b/app/services/portfolio.py
@@ -234,7 +234,7 @@ def run_portfolio_from_pdf(
     try:
         logger.info("[RAG-4] PDF 청킹 중...")
         all_chunks = chunk(tmp_path)
-        logger.info("[RAG-4] 청킹 완료: %d개 청크 (코드분석: %s)", len(all_chunks), "있음" if code_analysis else "없음")
+        logger.info("[RAG-4] 청킹 완료: %d개 청크 (코드분석: %s)", len(all_chunks), "있음" if code_analyses else "없음")
 
         img_chunks  = [c for c in all_chunks if c.get("sub_section") == "이미지"]
         text_chunks = [c for c in all_chunks if c.get("sub_section") != "이미지"]


### PR DESCRIPTION
## Issue #1 [CRITICAL] DB 커넥션 풀 없음 — 쿼리마다 TLS 핸드셰이크 반복

**위치**
- `app/services/_rag_utils.py:249` (`_vector_search`)
- `app/services/_rag_utils.py:300` (`_fetch_chunks`)
- `app/core/config.py:24` (`db_config`)

**문제**
청크 처리마다 `pg8000.connect()` → 쿼리 → `conn.close()` 사이클을 반복한다.
RDS 환경에서는 RTT 10-30ms + TLS 핸드셰이크 = **연결당 50~150ms** 오버헤드가 발생한다.
5청크 처리 기준으로 최소 10개의 신규 연결 = **순수 연결 오버헤드만 0.5~1.5초**.

**재현 조건**
모든 RAG 엔드포인트 (RDS 환경)

**해결 방향**
모듈 레벨 커넥션 풀 도입 (`DBUtils.PooledDB` 또는 pg8000 native pool).
`_vector_search`, `_fetch_chunks`가 풀에서 연결을 빌려 쓰도록 변경.

---

## Issue #2 [CRITICAL] async 백그라운드 태스크가 동기 코드를 이벤트 루프에서 직접 실행

**위치**
- `app/services/pdf_pipeline.py:59`

```python
async def run_job_pipeline(job_id, fn, tag=""):
    result = fn()   # ← sync 함수를 이벤트 루프에서 직접 호출
```

**문제**
`fn()`은 PDF 파싱, DB 쿼리, Gemini 호출 등 25~40초짜리 동기 작업이다.
`await` 없이 직접 호출하면 **단일 uvicorn 워커의 이벤트 루프 전체가 블로킹**된다.
Job 처리 중 상태 폴링(`GET /jobs/{id}`), 신규 요청 등 모든 요청이 처리 완료까지 대기한다.

**재현 조건**
모든 RAG 엔드포인트 요청 시

**해결 방향**
```python
result = await anyio.to_thread.run_sync(fn)
```
스레드 풀로 오프로드하면 이벤트 루프가 다른 요청을 계속 처리 가능하다.
`anyio`는 FastAPI 의존성으로 이미 설치되어 있다.

---

## Issue #3 [MEDIUM] BM25 인덱스 pickle을 매 검색마다 디스크에서 재로드

**위치**
- `app/services/_rag_utils.py:213-214` (`_bm25_search`)

```python
with open(bm25_path, "rb") as f:
    data = pickle.load(f)   # 매 검색마다 파일 I/O
```

**문제**
BM25 인덱스는 서버 실행 중 변하지 않는 불변 데이터임에도 매번 디스크에서 읽는다.
모든 RAG 요청에서 매 청크마다 BM25 검색이 실행되므로 불필요한 I/O가 반복된다.

**재현 조건**
모든 RAG 엔드포인트 요청 시

**해결 방향**
모듈 레벨 캐시 딕셔너리로 첫 로드 후 재사용:
```python
_bm25_cache: dict = {}

def _bm25_search(query, bm25_path, top_k):
    if bm25_path not in _bm25_cache:
        with open(bm25_path, "rb") as f:
            _bm25_cache[bm25_path] = pickle.load(f)
    data = _bm25_cache[bm25_path]
```
변경 난이도 낮음, 즉시 적용 가능.

---

## 우선순위 요약

| # | 이슈 | 심각도 | 수정 난이도 | 우선 순위 |
|---|------|--------|------------|----------|
| 2 | 이벤트 루프 블로킹 | CRITICAL | 낮음 (1줄) | ★★★★★ |
| 3 | BM25 캐시 | MEDIUM | 낮음 (5줄) | ★★★★☆ |
| 1 | DB 커넥션 풀 | CRITICAL | 중간 | ★★★★☆ |
