### PR TITLE
perf: 자소서 RAG 병렬처리 및 터미널 로그 출력 적용

### DIFF
--- a/app/evaluators/cover_letter.py
+++ b/app/evaluators/cover_letter.py
@@ -5,6 +5,7 @@ LLM 통합 평가: 지원동기·직무역량·인재상·작성품질 전 항�
 
 from __future__ import annotations
 
+import concurrent.futures
 import os
 import re
 
@@ -148,18 +149,24 @@ def llm_evaluate(text: str, char_limit: int | None = None, question: str = "") -
         context += f"[글자 수 제한: {char_limit}자, 실제 글자 수: {len(text.strip())}자]\n"
     if context:
         context += "\n"
-    resp = client.models.generate_content(
-        model=MODEL,
-        contents=f"{context}다음 자소서를 평가해주세요:\n\n{text}",
-        config=_genai_types.GenerateContentConfig(
-            system_instruction=_SYSTEM_PROMPT,
-            response_mime_type="application/json",
-            response_schema=_EvalResult,
-            temperature=0,
-            max_output_tokens=16384,
-        ),
-    )
-    return _EvalResult.model_validate_json(resp.text)
+
+    for attempt in range(3):
+        resp = client.models.generate_content(
+            model=MODEL,
+            contents=f"{context}다음 자소서를 평가해주세요:\n\n{text}",
+            config=_genai_types.GenerateContentConfig(
+                system_instruction=_SYSTEM_PROMPT,
+                response_mime_type="application/json",
+                response_schema=_EvalResult,
+                temperature=0,
+            ),
+        )
+        try:
+            return _EvalResult.model_validate_json(resp.text)
+        except Exception:
+            if attempt == 2:
+                raise
+    raise RuntimeError("llm_evaluate 재시도 실패")
 
 
 # ─── 가중 합산 ─────────────────────────────────────────────────────────────────
@@ -185,35 +192,29 @@ def grade_label(score: float) -> str:
 
 def print_result(llm: _EvalResult, weighted: float) -> None:
     sep = "─" * 52
-
     print(f"\n{'═'*52}")
     print(f"  자소서 평가 결과  |  모델: {MODEL}")
     print(f"{'═'*52}")
     print(f"  최종 점수  {weighted:6.2f} / 100   {grade_label(weighted)}")
     print(f"{'═'*52}\n")
-
     print(f"[A] {LABELS['A']}  ({int(WEIGHTS['A']*100)}%)  →  {llm.A.score}/100")
     print(f"    근거: {llm.A.reason}")
     print(f"    개선: {llm.A.fix}")
     print(sep)
-
     print(f"[B] {LABELS['B']}  ({int(WEIGHTS['B']*100)}%)  →  {llm.B.score}/100")
     print(f"    STAR 구조: {llm.B.star_score}/100  |  수치 성과: {llm.B.num_score}/100")
     print(f"    근거: {llm.B.reason}")
     print(f"    개선: {llm.B.fix}")
     print(sep)
-
     print(f"[C] {LABELS['C']}  ({int(WEIGHTS['C']*100)}%)  →  {llm.C.score}/100")
     print(f"    근거: {llm.C.reason}")
     print(f"    개선: {llm.C.fix}")
     print(sep)
-
     print(f"[D] {LABELS['D']}  ({int(WEIGHTS['D']*100)}%)  →  {llm.D.score}/80")
     print(f"    D1 분량: {llm.D.d1_volume}/40  |  D2 수치성과: {llm.D.d2_quant}/40  |  D3 감점: {llm.D.d3_penalty}")
     print(f"    근거: {llm.D.reason}")
     print(f"    개선: {llm.D.fix}")
     print(sep)
-
     print(f"\n  총평: {llm.overall}\n")
 
 
@@ -221,10 +222,11 @@ def print_result(llm: _EvalResult, weighted: float) -> None:
 
 @track_metrics
 def evaluate_comparison(original: str, improved: str, char_limit: int | None = None, question: str = "") -> dict:
-    print("\n  ── 원문 평가 ──")
-    before = evaluate(original, char_limit, question)
-    print("\n  ── 개선안 평가 ──")
-    after  = evaluate(improved, char_limit, question)
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+        f_before = executor.submit(evaluate, original, char_limit, question)
+        f_after  = executor.submit(evaluate, improved, char_limit, question)
+        before   = f_before.result()
+        after    = f_after.result()
 
     delta = round(after["weighted"] - before["weighted"], 2)
     sign  = "+" if delta >= 0 else ""
@@ -235,12 +237,10 @@ def evaluate_comparison(original: str, improved: str, char_limit: int | None = N
     print(f"{sep}")
     print(f"  {'항목':<12} {'원문':>6}  {'개선안':>6}  {'변화':>6}")
     print(f"  {'─'*40}")
-
     for k in ["A", "B", "C", "D"]:
         b = before["llm"][k]["score"]
         a = after["llm"][k]["score"]
         print(f"  {k}. {LABELS[k]:<10} {b:>6}  {a:>6}  {a-b:>+6}")
-
     print(f"  {'─'*40}")
     print(f"  {'최종 점수':<12} {before['weighted']:>6.2f}  {after['weighted']:>6.2f}  {sign}{delta:>+5.2f}")
     print(f"  {'등급':<12} {grade_label(before['weighted']):>8}  {grade_label(after['weighted']):>8}")
@@ -277,9 +277,7 @@ def evaluate(text: str, char_limit: int | None = None, question: str = "") -> di
 
     print("  [1/2] Gemini-3-Flash preview 평가 중...")
     llm = llm_evaluate(text, char_limit, question=question)
-
     print("  [2/2] 점수 합산 중...")
     weighted = compute_weighted(llm)
-
     print_result(llm, weighted)
     return {"llm": llm.model_dump(), "weighted": weighted}

--- a/app/services/cover_letter.py
+++ b/app/services/cover_letter.py
@@ -262,6 +262,7 @@ def run_cover_letter_from_pdf(
     career: str | None = None,
 ) -> dict:
     from docling.document_converter import DocumentConverter
+    from docling.datamodel.pipeline_options import PdfPipelineOptions
     from app.chunkers import cover_letter as cl_chunker
     from app.evaluators.cover_letter import evaluate_comparison, parse_char_limit
     from app.exporters.cover_letter_pdf import save_cl_improvement_pdf
@@ -269,27 +270,33 @@ def run_cover_letter_from_pdf(
     tmp_path = download_pdf_to_temp(pdf_s3_url)
     out_pdf  = make_output_path("cl_improvement")
     try:
-        converter = DocumentConverter()
+        from docling.document_converter import PdfFormatOption
+        from docling.datamodel.base_models import InputFormat
+        converter = DocumentConverter(
+            format_options={InputFormat.PDF: PdfFormatOption(pipeline_options=PdfPipelineOptions(do_ocr=False))}
+        )
         text      = converter.convert(tmp_path).document.export_to_text()
 
         logger.info("[RAG-1] 자소서 청킹 중...")
         chunks = cl_chunker.chunk(text, source="cover_letter")
         logger.info("[RAG-1] 청킹 완료: %d개 청크", len(chunks))
 
-        results = []
-        for idx, c in enumerate(chunks):
+        total_chunks = len(chunks)
+
+        def _process_chunk(args: tuple) -> dict:
+            idx, c = args
             section    = c.get("section", "")
             category   = c.get("category", "")
             char_limit = parse_char_limit(section)
 
-            logger.info("[RAG-1] [%d/%d] 텍스트 개선: %s / %s", idx + 1, len(chunks), section, category)
+            logger.info("[RAG-1] [%d/%d] 텍스트 개선: %s / %s", idx, total_chunks, section, category)
             result      = _improve_cover_letter_text(
                 c["text"], top_k=top_k, char_limit=char_limit, section=section,
                 job=job, career=career, use_rag=use_rag,
             )
             eval_result = evaluate_comparison(c["text"], result["improved"], char_limit=char_limit, question=section)
-
-            results.append({
+            logger.info("[RAG-1] [%d/%d] 완료: %s / %s", idx, total_chunks, section, category)
+            return {
                 "section":     section,
                 "category":    category,
                 "original":    c["text"],
@@ -300,7 +307,12 @@ def run_cover_letter_from_pdf(
                 "eval_after":  eval_result["after"]["weighted"],
                 "eval_delta":  eval_result["delta"],
                 "eval_detail": eval_result["per_category"],
-            })
+            }
+
+        max_workers = min(5, total_chunks)
+        with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+            futures = [executor.submit(_process_chunk, (i + 1, c)) for i, c in enumerate(chunks)]
+            results = [f.result() for f in futures]
 
         logger.info("[RAG-1] PDF 생성 중...")
         save_cl_improvement_pdf(results, out_pdf)
@@ -501,13 +513,18 @@ def run_cover_letter_to_portfolio(
     code_analyses: list[dict] = [],
 ) -> dict:
     from docling.document_converter import DocumentConverter
+    from docling.datamodel.pipeline_options import PdfPipelineOptions
     from app.chunkers import cover_letter as cl_chunker
     from app.exporters.portfolio_gen_pdf import save_generated_portfolio_pdf
 
     tmp_path = download_pdf_to_temp(pdf_s3_url)
     out_pdf  = make_output_path("cl_to_portfolio")
     try:
-        converter = DocumentConverter()
+        from docling.document_converter import PdfFormatOption
+        from docling.datamodel.base_models import InputFormat
+        converter = DocumentConverter(
+            format_options={InputFormat.PDF: PdfFormatOption(pipeline_options=PdfPipelineOptions(do_ocr=False))}
+        )
         text      = converter.convert(tmp_path).document.export_to_text()
 
         logger.info("[RAG-2] 자소서 청킹 중...")
@@ -520,13 +537,15 @@ def run_cover_letter_to_portfolio(
         chunks = [c for c in chunks if c.get("category", "") not in _EXCLUDE_CATEGORIES]
         logger.info("[RAG-2] 필터 후 %d개 청크 처리 예정", len(chunks))
 
-        client  = _get_gemini_client()
-        results = []
+        client       = _get_gemini_client()
+        total_chunks = len(chunks)
 
-        for idx, chunk in enumerate(chunks):
-            logger.info("[RAG-2] [%d/%d] 포트폴리오 섹션 생성: %s / %s", idx + 1, len(chunks), chunk.get("section", ""), chunk.get("category", ""))
-            refs = _search_portfolio_refs(chunk, top_k=top_k)
-            gen  = _generate_portfolio_section(chunk, refs, client, job=job, career=career, code_analyses=code_analyses)
+        def _process_chunk(args: tuple) -> dict:
+            from app.evaluators.portfolio import evaluate as pf_evaluate
+            idx, c = args
+            logger.info("[RAG-2] [%d/%d] 포트폴리오 섹션 생성: %s / %s", idx, total_chunks, c.get("section", ""), c.get("category", ""))
+            refs = _search_portfolio_refs(c, top_k=top_k)
+            gen  = _generate_portfolio_section(c, refs, client, job=job, career=career, code_analyses=code_analyses)
 
             full_text = "\n\n".join(filter(None, [
                 gen.sections.overview,
@@ -536,7 +555,6 @@ def run_cover_letter_to_portfolio(
             ]))
             eval_result = None
             if len(full_text.strip()) >= 50:
-                from app.evaluators.portfolio import evaluate as pf_evaluate
                 try:
                     eval_result = pf_evaluate(full_text, meta={
                         "period":     gen.period,
@@ -547,9 +565,10 @@ def run_cover_letter_to_portfolio(
                 except Exception:
                     pass
 
-            results.append({
-                "section":          chunk["section"],
-                "category":         chunk["category"],
+            logger.info("[RAG-2] [%d/%d] 완료: %s / %s", idx, total_chunks, c.get("section", ""), c.get("category", ""))
+            return {
+                "section":          c["section"],
+                "category":         c["category"],
                 "project":          gen.project,
                 "period":           gen.period,
                 "role":             gen.role,
@@ -565,7 +584,12 @@ def run_cover_letter_to_portfolio(
                     for g in gen.gaps
                 ],
                 "eval": eval_result,
-            })
+            }
+
+        max_workers = min(5, total_chunks)
+        with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+            futures = [executor.submit(_process_chunk, (i + 1, c)) for i, c in enumerate(chunks)]
+            results = [f.result() for f in futures]
 
         logger.info("[RAG-2] PDF 생성 중...")
         save_generated_portfolio_pdf(results, out_pdf)


### PR DESCRIPTION
- RAG-1: 청크별 LLM 개선 + 평가를 ThreadPoolExecutor로 병렬화
- RAG-2: 포트폴리오 섹션 생성을 ThreadPoolExecutor로 병렬화
- evaluate_comparison: 원문/개선안 평가 동시 실행 (max_workers=2)
- evaluator print_result: logger 대신 print()로 터미널 출력
- llm_evaluate: max_output_tokens 제거 + JSON 파싱 실패 시 3회 재시도
- DocumentConverter: do_ocr=False로 RapidOCR 로딩 제거