### PR TITLE
feat(roadmap): 완료 콜백을 result 포함 /roadmap/complete로 전송

### DIFF
--- a/app/services/roadmap_assess.py
+++ b/app/services/roadmap_assess.py
@@ -11,7 +11,7 @@ import anyio
 from app.services.roadmap import rule_filter, llm_analyzer, market_tier, market_loader
 from app.services.roadmap_merger import run_merged
 from app.services._rag_utils import _fetch_code_analysis as _fetch_project
-from app.services.webhook import notify_be
+from app.services.webhook import notify_be_roadmap
 from app.jobs.store import JobStatus, update_job
 
 logger = logging.getLogger(__name__)
@@ -197,7 +197,15 @@ async def run_assess_task(
         logger.error("[로드맵] 평가 태스크 실패: %s", e)
         update_job(job_id, JobStatus.ERROR, message=error_message)
     finally:
+        # 로드맵은 PDF가 없으므로 공용 /jobs/complete가 아니라 result를 싣는
+        # /roadmap/complete로 콜백한다(BE가 result_json 저장 후 FE로 전달).
+        status = "ERROR" if error_message else "DONE"
         try:
-            await notify_be(ai_job_id=ai_job_id, output_pdf_url=None, error_message=error_message)
+            await notify_be_roadmap(
+                ai_job_id=ai_job_id,
+                status=status,
+                result=results,
+                error_message=error_message,
+            )
         except Exception as webhook_err:
-            logger.warning("[Webhook] 콜백 실패 (결과는 저장됨): %s", webhook_err)
+            logger.warning("[Webhook] 로드맵 콜백 실패 (결과는 저장됨): %s", webhook_err)

--- a/app/services/webhook.py
+++ b/app/services/webhook.py
@@ -29,3 +29,27 @@ async def notify_be(
         resp = await client.post(be_url, json=payload, headers=headers)
         resp.raise_for_status()
     logger.info("[Webhook] 전송 완료: %s", ai_job_id)
+
+
+async def notify_be_roadmap(
+    ai_job_id: str,
+    status: str,
+    result: list | dict | None = None,
+    error_message: str | None = None,
+) -> None:
+    """로드맵 전용 완료 콜백. PDF가 없는 로드맵은 평가 결과(result)를 BE에 직접 실어 보낸다.
+    (포폴용 notify_be는 result를 싣지 않으므로 별도 엔드포인트로 분리.)"""
+    settings = get_settings()
+    payload = {
+        "ai_job_id":     ai_job_id,
+        "status":        status,
+        "result":        result,
+        "error_message": error_message,
+    }
+    be_url = f"{settings.be_base_url}/api/v1/ai/roadmap/complete"
+    headers = {"X-INTERNAL-API-KEY": settings.passfolio_internal_api_key}
+    logger.info("[Webhook] POST %s | status=%s | job=%s", be_url, status, ai_job_id)
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        resp = await client.post(be_url, json=payload, headers=headers)
+        resp.raise_for_status()
+    logger.info("[Webhook] 로드맵 전송 완료: %s", ai_job_id)


### PR DESCRIPTION
## 배경
로드맵 완료 콜백이 포폴/자소서용 공용 `notify_be`(`POST /api/v1/ai/jobs/complete`)를 쓰고 있어:
- PDF가 없는 로드맵은 `status`가 **항상 ERROR**로 전송됨(공용 로직: `status="DONE" if output_pdf_url else "ERROR"`).
- 평가 **result가 BE로 전달되지 않음**(공용 페이로드엔 result 없음).

→ BE가 로드맵 결과를 받아 FE로 흘릴 수 없었음(BE↔FE는 relay 정합 완료, 이 콜백만 비어 있던 상태).

## 변경
- `webhook.notify_be_roadmap(ai_job_id, status, result, error_message)` 추가 → `POST {BE}/api/v1/ai/roadmap/complete` (헤더 `X-INTERNAL-API-KEY` 동일).
- `run_assess_task` finally: 성공 시 `status=DONE`+`result`, 실패 시 `ERROR`+`error_message`로 `notify_be_roadmap` 호출(공용 `notify_be` 대신).
- 공용 `notify_be`(PDF 파이프라인용)는 **그대로 유지** — 변경 없음.

BE는 `/roadmap/complete`(`completeRoadmapJob`)에서 result를 `result_json`으로 저장 후 SSE/폴링으로 FE에 전달(BE/FE PR과 짝).

## 검증
- `python -m py_compile` 통과(문법). 공용 `notify_be`는 `pdf_pipeline`에서 계속 사용 — 무영향.

## 비고
- 베이스를 `main`으로 두었습니다. 팀 flow가 `develop` 우선이면 retarget 해주세요.
- `result`는 merge=false면 평가 배열, merge=true면 단건 배열로 전달(기존 result 구조 그대로).

🤖 Generated with [Claude Code](https://claude.com/claude-code)